### PR TITLE
Build arm64 architecture

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,8 +26,8 @@ jobs:
           - { os: 'bionic', baseruby: '2.5', tag: 'gcc-5',   extras: 'g++-5' }
           - { os: 'bionic', baseruby: '2.5', tag: 'gcc-4.8', extras: 'g++-4.8' }
 
-          - { os: 'focal',  baseruby: '2.7', tag: 'clang-14',  extras: 'llvm-14' }
-          - { os: 'focal',  baseruby: '2.7', tag: 'clang-13',  extras: 'llvm-13' }
+          - { os: 'focal',  baseruby: '2.7', tag: 'clang-14',  extras: 'llvm-14', platforms: 'linux/amd64' }
+          - { os: 'focal',  baseruby: '2.7', tag: 'clang-13',  extras: 'llvm-13', platforms: 'linux/amd64' }
           - { os: 'focal',  baseruby: '2.7', tag: 'clang-12',  extras: 'llvm-12' }
           - { os: 'focal',  baseruby: '2.7', tag: 'clang-11',  extras: 'llvm-11' }
           - { os: 'focal',  baseruby: '2.7', tag: 'clang-10',  extras: 'llvm-10' }
@@ -44,6 +44,8 @@ jobs:
           - { os: 'focal',   baseruby: '2.7', tag: 'crossbuild-essential-ppc64el' }
           - { os: 'focal',   baseruby: '2.7', tag: 'crossbuild-essential-s390x' }
 
+          - { os: 'focal', baseruby: '2.7', tag: 'build-essential', extras: 'libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev bison autoconf clang iproute2' }
+
     name: Publish ${{ matrix.entry.tag }}
     runs-on: ubuntu-latest
     steps:
@@ -53,7 +55,10 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-      - uses: docker/setup-buildx-action@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1
         with:
           username: ${{ github.actor }}
@@ -67,6 +72,7 @@ jobs:
             packages=${{ matrix.entry.tag }} ${{ matrix.entry.extras }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
+          platforms: ${{ matrix.entry.platforms || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/${{ github.repository }}:${{ matrix.entry.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,13 @@ COPY --from=assets /etc/ssl /etc/ssl
 COPY --from=assets /etc/apt /etc/apt
 COPY --from=assets /etc/dpkg /etc/dpkg
 
-RUN set -ex                                      \
- && apt-get update                               \
- && apt-get install ${packages}                  \
-    libjemalloc-dev openssl ruby tzdata valgrind \
- && apt-get build-dep ruby${baseruby}
+RUN apt-get update                               \
+ && apt-get install -y ${packages}                  \
+    libjemalloc-dev openssl ruby tzdata valgrind sudo \
+ && apt-get build-dep ruby${baseruby} \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN adduser --disabled-password --gecos '' ci && adduser ci sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+USER ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,11 @@ COPY --from=assets /etc/ssl /etc/ssl
 COPY --from=assets /etc/apt /etc/apt
 COPY --from=assets /etc/dpkg /etc/dpkg
 
-RUN apt-get update                               \
- && apt-get install -y ${packages}                  \
+RUN set -ex                                           \
+ && apt-get update                                    \
+ && apt-get install ${packages}                       \
     libjemalloc-dev openssl ruby tzdata valgrind sudo \
- && apt-get build-dep ruby${baseruby} \
- && rm -rf /var/lib/apt/lists/*
+ && apt-get build-dep ruby${baseruby}
 
 RUN adduser --disabled-password --gecos '' ci && adduser ci sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
So it's possible to run Arm CI using these images.

Note that Clang 13 and 14 are not available for Arm yet so I've disable building the multiarch images for them.

Plus I've added `build-essential` tag that can be used for running all the `ruby/ruby` tests. I've also created `ci` user in the image so filesystem tests can run properly. They assert system permissions and so on. 

Related PR is https://github.com/ruby/ruby/pull/4750

CC @junaruga as he helped me with figuring out some caveats.