### PR TITLE
Build arm64 architecture containers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,8 +26,9 @@ jobs:
           - { os: 'bionic', baseruby: '2.5', tag: 'gcc-5',   extras: 'g++-5' }
           - { os: 'bionic', baseruby: '2.5', tag: 'gcc-4.8', extras: 'g++-4.8' }
 
-          - { os: 'focal',  baseruby: '2.7', tag: 'clang-14',  extras: 'llvm-14' }
-          - { os: 'focal',  baseruby: '2.7', tag: 'clang-13',  extras: 'llvm-13' }
+          # The clang-14, 13 arm64 are not available.
+          - { os: 'focal',  baseruby: '2.7', tag: 'clang-14',  extras: 'llvm-14', platforms: 'linux/amd64' }
+          - { os: 'focal',  baseruby: '2.7', tag: 'clang-13',  extras: 'llvm-13', platforms: 'linux/amd64' }
           - { os: 'focal',  baseruby: '2.7', tag: 'clang-12',  extras: 'llvm-12' }
           - { os: 'focal',  baseruby: '2.7', tag: 'clang-11',  extras: 'llvm-11' }
           - { os: 'focal',  baseruby: '2.7', tag: 'clang-10',  extras: 'llvm-10' }
@@ -53,6 +54,7 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
+      - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1
         with:
@@ -67,6 +69,7 @@ jobs:
             packages=${{ matrix.entry.tag }} ${{ matrix.entry.extras }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
+          platforms: ${{ matrix.entry.platforms || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/${{ github.repository }}:${{ matrix.entry.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,13 @@ COPY --from=assets /etc/ssl /etc/ssl
 COPY --from=assets /etc/apt /etc/apt
 COPY --from=assets /etc/dpkg /etc/dpkg
 
-RUN set -ex                                      \
- && apt-get update                               \
- && apt-get install ${packages}                  \
-    libjemalloc-dev openssl ruby tzdata valgrind \
+RUN set -ex                                           \
+ && apt-get update                                    \
+ && apt-get install ${packages}                       \
+    libjemalloc-dev openssl ruby tzdata valgrind sudo \
  && apt-get build-dep ruby${baseruby}
+
+RUN adduser --disabled-password --gecos '' ci && adduser ci sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+USER ci


### PR DESCRIPTION
This PR is rebase from the PR: #2 .

I wanted to adjust the commit units with adding comment explaining the context.

The 1st commit is to build and push the arm64 container images.
The 2nd commit is to add the testing user `ci` and `sudo` for the convenience.

A small change from the #2 is 

* Added comment on the line 29.
* Removed the `- name:` syntax, because currently it is not used in the `publish.yml`.
* Dropped the new case `- { os: 'focal', baseruby: '2.7', tag: 'build-essential', extras: 'libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev bison autoconf clang iproute2' }`, because I am not sure that it is needed. The current existing container images already has the build dependencies.

The testing container image repo on my fork repo is here.
https://github.com/users/junaruga/packages/container/package/ruby-ci-image

The CI result is here.
https://github.com/junaruga/ruby-ci-image/actions/runs/1159838373


