### PR TITLE
Base images

### DIFF
--- a/.github/workflows/base-images.yml
+++ b/.github/workflows/base-images.yml
@@ -1,0 +1,58 @@
+name: Publish (Base Images)
+
+on:
+  release:
+    types: [published]
+  push:
+  schedule:
+
+    # Everyday Wednesday on 01:32 UTC.  This timing is handy because while
+    # European countries are in midnight, American countries are still in
+    # their evening and Asian countries are in the next morning.
+    - cron: '32 1 * * 3'
+
+jobs:
+  push:
+    strategy:
+      fail-fast: false
+      matrix:
+        entry:
+          - { os: 'bionic',  baseruby: '2.5', tag: 'ubuntu-18.04' }
+          - { os: 'focal',   baseruby: '2.7', tag: 'ubuntu-20.04' }
+          - { os: 'hirsute', baseruby: '2.7', tag: 'ubuntu-21.04' }
+          - { os: 'impish',  baseruby: '2.7', tag: 'ubuntu-21.10' }
+
+    name: Publish ${{ matrix.entry.tag }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.ACCESS_TOKEN }}
+          registry: ghcr.io
+      - uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            version=${{ matrix.entry.os }}
+            baseruby=${{ matrix.entry.baseruby }}
+            packages=
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          platforms: 'linux/amd64,linux/arm64'
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ matrix.entry.tag }}
+
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,10 +40,10 @@ jobs:
           - { os: 'bionic', baseruby: '2.5', tag: 'clang-4.0', extras: 'llvm-4.0' }
           - { os: 'bionic', baseruby: '2.5', tag: 'clang-3.9', extras: 'llvm-3.9' }
 
-          - { os: 'focal',   baseruby: '2.7', tag: 'mingw-w64' }
-          - { os: 'focal',   baseruby: '2.7', tag: 'crossbuild-essential-arm64' }
-          - { os: 'focal',   baseruby: '2.7', tag: 'crossbuild-essential-ppc64el' }
-          - { os: 'focal',   baseruby: '2.7', tag: 'crossbuild-essential-s390x' }
+          - { os: 'focal',  baseruby: '2.7', tag: 'mingw-w64' }
+          - { os: 'focal',  baseruby: '2.7', tag: 'crossbuild-essential-arm64' }
+          - { os: 'focal',  baseruby: '2.7', tag: 'crossbuild-essential-ppc64el' }
+          - { os: 'focal',  baseruby: '2.7', tag: 'crossbuild-essential-s390x' }
 
     name: Publish ${{ matrix.entry.tag }}
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN set -ex                                           \
  && apt-get update                                    \
  && apt-get install ${packages}                       \
     libjemalloc-dev openssl ruby tzdata valgrind sudo \
+    git \
  && apt-get build-dep ruby${baseruby}
 
 RUN adduser --disabled-password --gecos '' ci && adduser ci sudo

--- a/assets/99hirsute.list
+++ b/assets/99hirsute.list
@@ -1,0 +1,5 @@
+deb http://ppa.launchpad.net/ubuntu-toolchain-r/ppa/ubuntu hirsute main
+deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu hirsute main
+
+deb-src http://ppa.launchpad.net/ubuntu-toolchain-r/ppa/ubuntu hirsute main
+deb-src http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu hirsute main

--- a/assets/99impish.list
+++ b/assets/99impish.list
@@ -1,0 +1,5 @@
+deb http://ppa.launchpad.net/ubuntu-toolchain-r/ppa/ubuntu impish main
+deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu impish main
+
+deb-src http://ppa.launchpad.net/ubuntu-toolchain-r/ppa/ubuntu impish main
+deb-src http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu impish main


### PR DESCRIPTION
Implement "base" images, which have no extra packages, so that Ruby's CI can avoid `apt-get install build-essential ...`