### PR TITLE
Resolve the build failure with psych

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY --from=assets /etc/sudoers.d /etc/sudoers.d
 RUN set -ex                                           \
  && apt-get update                                    \
  && apt-get install ${packages}                       \
-    libjemalloc-dev openssl ruby tzdata valgrind sudo \
+    libjemalloc-dev openssl libyaml-dev ruby tzdata valgrind sudo \
  && apt-get build-dep ruby${baseruby}
 
 RUN adduser --disabled-password --gecos '' ci && adduser ci sudo


### PR DESCRIPTION
I removed the bundled libyaml source from psych at https://github.com/ruby/psych/pull/541.

I added libyaml lib and headers into docker images of Ruby CI actions.
