### PR TITLE
Install rustc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN set -ex                                           \
  && apt-get update                                    \
  && apt-get install ${packages}                       \
     libjemalloc-dev openssl ruby tzdata valgrind sudo \
+    libcapstone-dev                                   \
  && apt-get build-dep ruby${baseruby}
 
 RUN adduser --disabled-password --gecos '' ci && adduser ci sudo

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,23 @@ ADD assets/99${version}.list /etc/apt/sources.list.d/
 ADD assets/sudoers /etc/sudoers.d/
 RUN chmod 0440 /etc/sudoers.d/*
 
+RUN mkdir /rust
+RUN wget                         \
+      --https-only               \
+      --secure-protocol=TLSv1_2  \
+      --output-document=-        \
+      https://sh.rustup.rs       \
+  | env                          \
+      RUSTUP_HOME=/rust/rustup   \
+      CARGO_HOME=/rust/cargo     \
+    /bin/sh                      \
+      -s                         \
+      --                         \
+      --default-toolchain=stable \
+      --profile=minimal          \
+      --no-modify-path           \
+      -y
+
 FROM ${os}:${version}${variant} as compilers
 ARG baseruby
 ARG packages
@@ -35,6 +52,9 @@ COPY --from=assets /etc/ssl /etc/ssl
 COPY --from=assets /etc/apt /etc/apt
 COPY --from=assets /etc/dpkg /etc/dpkg
 COPY --from=assets /etc/sudoers.d /etc/sudoers.d
+COPY --from=assets /rust /rust
+ENV RUSTUP_HOME=/rust/rustup
+ENV PATH=${PATH}:/rust/cargo/bin
 
 RUN set -ex                                           \
  && apt-get update                                    \


### PR DESCRIPTION
We are not going to `apt-get install rustc`, because what is installed using apt-get tends to be too old, compared to what we need (1.60.0+).