### PR TITLE
libreadline-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN set -ex                                           \
  && apt-get update                                    \
  && apt-get install ${packages}                       \
     libjemalloc-dev openssl libyaml-dev ruby tzdata valgrind sudo docker.io \
+    libreadline-dev \
  && apt-get build-dep ruby${baseruby}
 
 RUN adduser --disabled-password --gecos '' ci && adduser ci sudo


### PR DESCRIPTION
It seems build failure in https://github.com/ruby/ruby/actions/runs/3086658450/jobs/4991233263 is due to absence of this header.