### PR TITLE
use of type=gha

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,12 +51,6 @@ jobs:
     name: Publish ${{ matrix.entry.tag }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1
@@ -70,15 +64,9 @@ jobs:
             version=${{ matrix.entry.os }}
             baseruby=${{ matrix.entry.baseruby }}
             packages=${{ matrix.entry.tag }} ${{ matrix.entry.extras }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          cache-from: type=gha
+          cache-to: type=gha
           platforms: ${{ matrix.entry.platforms || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/${{ github.repository }}:${{ matrix.entry.tag }}
-
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
https://github.com/moby/buildkit/pull/1974 is merged.  We no longer need extra manoeuvre to cache builds. See also https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache