### PR TITLE
reduce max-parallel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   push:
     strategy:
+      max-parallel: 5
       fail-fast: false
       matrix:
         entry:


### PR DESCRIPTION
Scheduled runs are flaky these days
<img width="592" alt="Screen Shot 2023-05-08 at 12 14 27" src="https://user-images.githubusercontent.com/15377/236725948-365405bb-fe20-4101-8064-6c777196a646.png">

It seems ghcr.io cuts too many requests to put images at once.  Let's reduce parallelism.