### PR TITLE
Build Ruby 3.0 for old distributions (take 3)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,34 +19,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Ruby 3.4 requires BASERUBY 3.0
         entry:
-          - { os: 'lunar', baseruby: '3.1', tag: 'gcc-13',  extras: 'g++-13' }
-          - { os: 'jammy', baseruby: '3.0', tag: 'gcc-12',  extras: 'g++-12' }
-          - { os: 'focal', baseruby: '2.7', tag: 'gcc-11',  extras: 'g++-11' }
-          - { os: 'focal', baseruby: '2.7', tag: 'gcc-10',  extras: 'g++-10' }
-          - { os: 'focal', baseruby: '2.7', tag: 'gcc-9',   extras: 'g++-9' }
-          - { os: 'focal', baseruby: '2.7', tag: 'gcc-8',   extras: 'g++-8' }
-          - { os: 'focal', baseruby: '2.7', tag: 'gcc-7',   extras: 'g++-7' }
+          - { os: 'lunar', system_ruby: '3.1', tag: 'gcc-13',  extras: 'g++-13' }
+          - { os: 'jammy', system_ruby: '3.0', tag: 'gcc-12',  extras: 'g++-12' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'gcc-11',  extras: 'g++-11' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'gcc-10',  extras: 'g++-10' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'gcc-9',   extras: 'g++-9' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'gcc-8',   extras: 'g++-8' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'gcc-7',   extras: 'g++-7' }
 
           # The clang-14, 13 arm64 are not available.
-          - { os: 'jammy', baseruby: '3.0', tag: 'clang-18',  extras: 'llvm-18', platforms: 'linux/amd64' }
-          - { os: 'jammy', baseruby: '3.0', tag: 'clang-17',  extras: 'llvm-17', platforms: 'linux/amd64' }
-          - { os: 'jammy', baseruby: '3.0', tag: 'clang-16',  extras: 'llvm-16', platforms: 'linux/amd64' }
-          - { os: 'focal', baseruby: '2.7', tag: 'clang-15',  extras: 'llvm-15', platforms: 'linux/amd64' }
-          - { os: 'focal', baseruby: '2.7', tag: 'clang-14',  extras: 'llvm-14', platforms: 'linux/amd64' }
-          - { os: 'focal', baseruby: '2.7', tag: 'clang-13',  extras: 'llvm-13', platforms: 'linux/amd64' }
-          - { os: 'focal', baseruby: '2.7', tag: 'clang-12',  extras: 'llvm-12' }
-          - { os: 'focal', baseruby: '2.7', tag: 'clang-11',  extras: 'llvm-11' }
-          - { os: 'focal', baseruby: '2.7', tag: 'clang-10',  extras: 'llvm-10' }
-          - { os: 'focal', baseruby: '2.7', tag: 'clang-9',   extras: 'llvm-9' }
-          - { os: 'focal', baseruby: '2.7', tag: 'clang-8',   extras: 'llvm-8' }
-          - { os: 'focal', baseruby: '2.7', tag: 'clang-7',   extras: 'llvm-7' }
-          - { os: 'focal', baseruby: '2.7', tag: 'clang-6.0', extras: 'llvm-6.0' }
+          - { os: 'jammy', system_ruby: '3.0', tag: 'clang-18',  extras: 'llvm-18', platforms: 'linux/amd64' }
+          - { os: 'jammy', system_ruby: '3.0', tag: 'clang-17',  extras: 'llvm-17', platforms: 'linux/amd64' }
+          - { os: 'jammy', system_ruby: '3.0', tag: 'clang-16',  extras: 'llvm-16', platforms: 'linux/amd64' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'clang-15',  extras: 'llvm-15', platforms: 'linux/amd64' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'clang-14',  extras: 'llvm-14', platforms: 'linux/amd64' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'clang-13',  extras: 'llvm-13', platforms: 'linux/amd64' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'clang-12',  extras: 'llvm-12' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'clang-11',  extras: 'llvm-11' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'clang-10',  extras: 'llvm-10' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'clang-9',   extras: 'llvm-9' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'clang-8',   extras: 'llvm-8' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'clang-7',   extras: 'llvm-7' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'clang-6.0', extras: 'llvm-6.0' }
 
-          - { os: 'focal', baseruby: '2.7', tag: 'mingw-w64' }
-          - { os: 'focal', baseruby: '2.7', tag: 'crossbuild-essential-arm64' }
-          - { os: 'focal', baseruby: '2.7', tag: 'crossbuild-essential-ppc64el' }
-          - { os: 'focal', baseruby: '2.7', tag: 'crossbuild-essential-s390x' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'mingw-w64' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'crossbuild-essential-arm64' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'crossbuild-essential-ppc64el' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'crossbuild-essential-s390x' }
 
     name: Publish ${{ matrix.entry.tag }}
     runs-on: ubuntu-latest
@@ -58,11 +59,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.ACCESS_TOKEN }}
           registry: ghcr.io
+      - name: Resolve build_ruby version
+        uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
+        with:
+          ruby-version: '${{ matrix.entry.build_ruby }}'
+          bundler: none
+        if: ${{ matrix.entry.build_ruby != '' }}
+      - name: Set build_ruby version
+        id: build_ruby
+        run: ruby -e 'puts "::set-output name=version::#{RUBY_VERSION}"'
+        if: ${{ matrix.entry.build_ruby != '' }}
       - uses: docker/build-push-action@v4
         with:
           build-args: |
             version=${{ matrix.entry.os }}
-            baseruby=${{ matrix.entry.baseruby }}
+            build_ruby=${{ steps.build_ruby.outputs.version }}
+            system_ruby=${{ matrix.entry.system_ruby }}
             packages=${{ matrix.entry.tag }} ${{ matrix.entry.extras }}
           cache-from: type=gha
           cache-to: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ COPY build_ruby.sh /tmp
 RUN set -ex                                           \
  && apt-get update                                    \
  && apt-get install ${packages}                       \
-    libjemalloc-dev openssl libyaml-dev zlib1g-dev tzdata valgrind wget ca-certificates sudo docker.io \
+    libjemalloc-dev libssl-dev libyaml-dev zlib1g-dev tzdata valgrind wget ca-certificates sudo docker.io \
     libreadline-dev libcapstone-dev \
  && apt-get build-dep ruby${system_ruby} \
  && bash -c "if [[ -n '$system_ruby' ]]; then apt-get install 'ruby${system_ruby}'; fi" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 ARG os=ubuntu
 ARG version=
 ARG variant=
-ARG baseruby=
+ARG build_ruby=
+ARG system_ruby=
 ARG packages=
 
 FROM ${os}:${version}${variant} as assets
@@ -46,7 +47,8 @@ RUN wget                         \
       -y
 
 FROM ${os}:${version}${variant} as compilers
-ARG baseruby
+ARG build_ruby
+ARG system_ruby
 ARG packages
 
 LABEL maintainer=shyouhei@ruby-lang.org
@@ -59,12 +61,16 @@ COPY --from=assets /rust /rust
 ENV RUSTUP_HOME=/rust/rustup
 ENV PATH=${PATH}:/rust/cargo/bin
 
+COPY build_ruby.sh /tmp
 RUN set -ex                                           \
  && apt-get update                                    \
  && apt-get install ${packages}                       \
-    libjemalloc-dev openssl libyaml-dev ruby tzdata valgrind sudo docker.io \
+    libjemalloc-dev openssl libyaml-dev zlib1g-dev tzdata valgrind wget ca-certificates sudo docker.io \
     libreadline-dev libcapstone-dev \
- && apt-get build-dep ruby${baseruby}
+ && apt-get build-dep ruby${system_ruby} \
+ && bash -c "if [[ -n '$system_ruby' ]]; then apt-get install 'ruby${system_ruby}'; fi" \
+ && bash -c "if [[ -n '$build_ruby' ]]; then /tmp/build_ruby.sh '$build_ruby'; fi" \
+ && rm /tmp/build_ruby.sh
 
 RUN adduser --disabled-password --gecos '' ci && adduser ci sudo
 

--- a/build_ruby.sh
+++ b/build_ruby.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euxo pipefail
+
+ruby_version="$1"
+
+mkdir /tmp/build_ruby
+trap 'rm -rf /tmp/build_ruby' EXIT
+cd /tmp/build_ruby
+
+wget "https://cache.ruby-lang.org/pub/ruby/${ruby_version:0:3}/ruby-${ruby_version}.tar.gz"
+tar xvzf "ruby-${ruby_version}.tar.gz"
+cd "ruby-${ruby_version}"
+
+./configure --disable-install-doc
+make -j
+make install


### PR DESCRIPTION
This fixes the `require "openssl"` error locally.