### PR TITLE
Split builds for each platform

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,13 +29,12 @@ jobs:
           - { os: 'focal',  build_ruby: '3.0', tag: 'gcc-8',   extras: 'g++-8' }
           - { os: 'focal',  build_ruby: '3.0', tag: 'gcc-7',   extras: 'g++-7' }
 
-          # The clang-14, 13 arm64 are not available.
-          - { os: 'jammy', system_ruby: '3.0', tag: 'clang-18',  extras: 'llvm-18', platforms: 'linux/amd64' }
-          - { os: 'jammy', system_ruby: '3.0', tag: 'clang-17',  extras: 'llvm-17', platforms: 'linux/amd64' }
-          - { os: 'jammy', system_ruby: '3.0', tag: 'clang-16',  extras: 'llvm-16', platforms: 'linux/amd64' }
-          - { os: 'focal',  build_ruby: '3.0', tag: 'clang-15',  extras: 'llvm-15', platforms: 'linux/amd64' }
-          - { os: 'focal',  build_ruby: '3.0', tag: 'clang-14',  extras: 'llvm-14', platforms: 'linux/amd64' }
-          - { os: 'focal',  build_ruby: '3.0', tag: 'clang-13',  extras: 'llvm-13', platforms: 'linux/amd64' }
+          - { os: 'jammy', system_ruby: '3.0', tag: 'clang-18',  extras: 'llvm-18' }
+          - { os: 'jammy', system_ruby: '3.0', tag: 'clang-17',  extras: 'llvm-17' }
+          - { os: 'jammy', system_ruby: '3.0', tag: 'clang-16',  extras: 'llvm-16' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'clang-15',  extras: 'llvm-15' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'clang-14',  extras: 'llvm-14' }
+          - { os: 'focal',  build_ruby: '3.0', tag: 'clang-13',  extras: 'llvm-13' }
           - { os: 'focal',  build_ruby: '3.0', tag: 'clang-12',  extras: 'llvm-12' }
           - { os: 'focal',  build_ruby: '3.0', tag: 'clang-11',  extras: 'llvm-11' }
           - { os: 'focal',  build_ruby: '3.0', tag: 'clang-10',  extras: 'llvm-10' }
@@ -48,8 +47,11 @@ jobs:
           - { os: 'focal',  build_ruby: '3.0', tag: 'crossbuild-essential-arm64' }
           - { os: 'focal',  build_ruby: '3.0', tag: 'crossbuild-essential-ppc64el' }
           - { os: 'focal',  build_ruby: '3.0', tag: 'crossbuild-essential-s390x' }
+        platforms:
+          - 'linux/amd64'
+          - 'linux/arm64'
 
-    name: Publish ${{ matrix.entry.tag }}
+    name: Publish ${{ matrix.entry.tag }} ${{ matrix.platforms }}
     runs-on: ubuntu-latest
     steps:
       - uses: docker/setup-qemu-action@v2
@@ -78,7 +80,7 @@ jobs:
             packages=${{ matrix.entry.tag }} ${{ matrix.entry.extras }}
           cache-from: type=gha
           cache-to: type=gha
-          platforms: ${{ matrix.entry.platforms || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ matrix.platforms }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/${{ github.repository }}:${{ matrix.entry.tag }}


### PR DESCRIPTION
arm64 builds on QEMU are very slow. Since we only use amd64 on ruby/ruby CI, it's nice to complete amd64 jobs early.