### PR TITLE
Ignore cache export failures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,8 +78,8 @@ jobs:
             build_ruby=${{ steps.build_ruby.outputs.version }}
             system_ruby=${{ matrix.entry.system_ruby }}
             packages=${{ matrix.entry.tag }} ${{ matrix.entry.extras }}
-          cache-from: type=gha
-          cache-to: type=gha
+          cache-from: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
           platforms: ${{ matrix.arch.platforms }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: |


### PR DESCRIPTION
ref: https://github.com/moby/buildkit/issues/2492

Cache export randomly timeouts. Cache export failures are not fatal, so let's just ignore them.

I also added `mode=max` that I happened to discover, which would hopefully maximize our cache efficiency.