### PR TITLE
Explicitly install build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,9 +65,9 @@ COPY build_ruby.sh /tmp
 RUN set -ex                                           \
  && apt-get update                                    \
  && apt-get install ${packages}                       \
-    libjemalloc-dev libssl-dev libyaml-dev zlib1g-dev tzdata valgrind wget ca-certificates sudo docker.io \
-    libreadline-dev libcapstone-dev \
- && apt-get build-dep ruby${system_ruby} \
+    autoconf patch build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev \
+    libgmp-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev libdb-dev uuid-dev \
+    libjemalloc-dev tzdata valgrind wget ca-certificates sudo docker.io libcapstone-dev \
  && bash -c "if [[ -n '$system_ruby' ]]; then apt-get install 'ruby${system_ruby}'; fi" \
  && bash -c "if [[ -n '$build_ruby' ]]; then /tmp/build_ruby.sh '$build_ruby'; fi" \
  && rm /tmp/build_ruby.sh


### PR DESCRIPTION
`apt-get build-dep ruby3.0` installs bison, but `apt-get build-dep ruby` doesn't, which is still necessary for `ruby_3_2` branch.

I don't want to manage the system ruby version for images that don't need a system ruby, so this PR explicitly specifies what https://github.com/rbenv/ruby-build/wiki#ubuntudebianmint says.