### PR TITLE
Update contributing steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A pipeline to publish Ruby CI container images to <http://ghcr.io/ruby/ruby-ci-i
 If you want to test the container images on your forked repository with your container registry, the steps are as follows. You need to set a token up to push the containers to your container registry, as the [`docker/login-action`](https://github.com/docker/login-action#github-container-registry) uses it in `.github/workflows/publish.yml`.
 
 1. Fork this repository.
-2. Add your personal access token with checking write:packages at <https://github.com/settings/tokens>, then you get the token.
-3. Add the `ACCESS_TOKEN` as a value you got above, on your forked repository "your_name/ruby-ci-image" Setting - Actions - Secrets.
-4. When you push a branch to your forked repository, GitHub Actions is executed.
-5. Check your container registry page, <https://github.com/users/your_name/packages/container/package/ruby-ci-image>. You can pull the container images by `docker`.
+2. Add your personal access token with checking write:packages at [Tokens (classic) page](https://github.com/settings/tokens), then you get the token.
+3. Add the `ACCESS_TOKEN` as a value you got above, at Setting - Security - Secrets and variables - Actions - Actions secrets and variables page - Secrets tab on your forked repository "your_name/ruby-ci-image".
+4. If you want to execute GitHub Actions workflow to test the container images on push on any branches, comment out the `on.push.branches` syntax in the `publish.yml`.
+5. When you push a branch to your forked repository, GitHub Actions workflow is executed.
+6. Check your container registry page, <https://github.com/users/your_name/packages/container/package/ruby-ci-image>. You can pull the container images by `docker`.


### PR DESCRIPTION
I noticed some updates at Tokens page and Secret page on GitHub. So, I updated the contributing steps. Below are the details. You can check the updated README [here](https://github.com/junaruga/ruby-ci-image/blob/wip/doc-contributing/README.md) on my forked repository.

---

* Now there are 2 kinds of token pages "Tokens (classic)" and "Fine-grained personal access tokens" on GitHub. Clarified the token page name.
* Updated the menu tree to the Secrets page, as it was changed.
* Added a step to comment out the `branches` syntax to run GitHub Actions on push on any branches.
* Replaced the grammatically wrong "GitHub Actions is executed" with "GitHub Actions workflow is executed"

[ci skip]