### PR TITLE
Install Launchable CLI in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,14 @@ RUN set -ex                                           \
 
 RUN adduser --disabled-password --gecos '' ci && adduser ci sudo
 
+# Setup Launchable
+RUN apt-get install -y --no-install-recommends \
+  python3-venv \
+  python3-setuptools \
+  python3-pip \
+  pipx \
+  openjdk-8-jdk
+ENV PATH="$PATH:/root/.local/bin"
+RUN pipx install launchable
+
 USER ci


### PR DESCRIPTION
Recently, Launchable has been used for analyzing flaky tests. Endoh-san wanted to record tests in compilers.yml for analyzing flay tests, so I've created this PR to address it.

Examples for using Launchable:

https://github.com/ruby/ruby/pull/11025
https://github.com/ruby/ruby/pull/10749