### PR TITLE
Skip login when the PR is from fork repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.ACCESS_TOKEN }}
           registry: ghcr.io
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.fork == false }}
 
       - name: Resolve build_ruby version
         uses: ruby/setup-ruby@7d3497fd78c07c0d84ebafa58d8dac60cd1f0763 # v1.199.0


### PR DESCRIPTION
Currently, this CI always failed in the process of logging in when the PR is from the fork repository. Here is the example: https://github.com/ruby/ruby-ci-image/pull/73.

So, I've added skip logic for skipping the login step when the PR is from fork repo.