### PR TITLE
Use noble image for gcc-13

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         # Ruby 3.4 requires BASERUBY 3.0
         entry:
           - { os: 'noble', tag: 'gcc-14', extras: 'g++-14' }
-          - { os: 'lunar', tag: 'gcc-13', extras: 'g++-13' }
+          - { os: 'noble', tag: 'gcc-13', extras: 'g++-13' }
           - { os: 'jammy', tag: 'gcc-12', extras: 'g++-12' }
           - { os: 'jammy', tag: 'gcc-11', extras: 'g++-11' }
           - { os: 'jammy', tag: 'gcc-10', extras: 'g++-10' }

--- a/assets/99lunar.list
+++ b/assets/99lunar.list
@@ -1,7 +1,0 @@
-deb [signed-by=/etc/apt/keyrings/ubuntu-toolchain-r.asc] http://ppa.launchpad.net/ubuntu-toolchain-r/ppa/ubuntu lunar main
-deb [signed-by=/etc/apt/keyrings/ubuntu-toolchain-r.asc] http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu lunar main
-deb [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg.key.asc] http://apt.llvm.org/lunar/ llvm-toolchain-lunar main
-
-deb-src [signed-by=/etc/apt/keyrings/ubuntu-toolchain-r.asc] http://ppa.launchpad.net/ubuntu-toolchain-r/ppa/ubuntu lunar main
-deb-src [signed-by=/etc/apt/keyrings/ubuntu-toolchain-r.asc] http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu lunar main
-deb-src [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg.key.asc] http://apt.llvm.org/lunar/ llvm-toolchain-lunar main


### PR DESCRIPTION
`lunar` repo has been removed from ubuntu.com.

see https://github.com/ruby/ruby-ci-image/actions/runs/12229092681/job/34108335280?pr=81 